### PR TITLE
apply extern patch

### DIFF
--- a/program/psiconv/psiconv.c
+++ b/program/psiconv/psiconv.c
@@ -48,6 +48,8 @@ static void print_help(void);
 static void print_version(void);
 static void strtoupper(char *str);
 
+psiconv_list fileformat_list; /* of struct psiconv_fileformat */
+
 void print_help(void)
 {
   fileformat ff;

--- a/program/psiconv/psiconv.h
+++ b/program/psiconv/psiconv.h
@@ -52,7 +52,7 @@ typedef struct fileformat_s {
   output_function *output;
 } *fileformat;
 
-psiconv_list fileformat_list; /* of struct psiconv_fileformat */
+extern psiconv_list fileformat_list; /* of struct psiconv_fileformat */
 
 
 #endif /* PSICONV_H */


### PR DESCRIPTION
apply patch to fix "multiple definition of `fileformat_list'" error
modern GCC is more strict
I originally found this patch at https://github.com/pld-linux/psiconv/blob/master/psiconv-extern.patch